### PR TITLE
FEAT - Add Flyway Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,9 @@
 import org.jooq.util.GenerationTool
+import org.yaml.snakeyaml.Yaml
 
-apply plugin: 'idea'
-apply plugin: 'java'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
-repositories {
-    mavenCentral()
-}
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 buildscript {
     repositories {
@@ -19,7 +14,21 @@ buildscript {
     dependencies {
         classpath 'org.jooq:jooq-codegen:3.10.6'        // jOOQ code generation package
         classpath 'org.xerial:sqlite-jdbc:3.21.0.1'     // used by generateJooq to connect to DB
+        classpath 'org.yaml:snakeyaml:1.18'             // Yaml parser
     }
+}
+
+plugins {
+    id 'idea'
+    id 'java'
+    id 'org.flywaydb.flyway' version '5.0.7'
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+    mavenCentral()
 }
 
 dependencies {
@@ -61,4 +70,23 @@ task generateJooq {
     doLast {
         GenerationTool.generate(file('jooq-config.xml').text)
     }
+}
+
+// Flyway plugin
+flyway {
+    def config = new Yaml().load(file('jivecoin.yml').text)
+    String configUrl = config.database.url
+
+    // make sure the blockchain store is present
+    String[] parts = configUrl.split(':')
+    if (parts.length < 3) {
+        throw new RuntimeException('Configuration for the database URL is missing hostname')
+    }
+    Path blockchainStore = Paths.get(parts[2])
+    if (Files.notExists(blockchainStore)) {
+        Path dir = blockchainStore.getParent()
+        Files.createDirectories(dir)
+    }
+
+    url = configUrl
 }

--- a/src/main/java/com/jivecoin/app/bundle/FlywayBundle.java
+++ b/src/main/java/com/jivecoin/app/bundle/FlywayBundle.java
@@ -1,6 +1,5 @@
 package com.jivecoin.app.bundle;
 
-import com.codahale.metrics.MetricRegistry;
 import com.jivecoin.app.JiveCoinConfiguration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.db.DataSourceFactory;
@@ -17,7 +16,6 @@ import java.nio.file.Paths;
 public class FlywayBundle implements ConfiguredBundle<JiveCoinConfiguration> {
 
     private final Flyway flyway;
-    MetricRegistry metricRegistry;
 
     public FlywayBundle(Flyway flyway) {
         this.flyway = flyway;
@@ -26,7 +24,7 @@ public class FlywayBundle implements ConfiguredBundle<JiveCoinConfiguration> {
     @Override
     public void run(JiveCoinConfiguration configuration, Environment environment) throws IOException {
         DataSourceFactory dsFactory = configuration.database;
-        DataSource ds = dsFactory.build(metricRegistry, "flyway");
+        DataSource ds = dsFactory.build(environment.metrics(), "flyway");
         // point flyway to the database
         flyway.setDataSource(ds);
 
@@ -39,7 +37,6 @@ public class FlywayBundle implements ConfiguredBundle<JiveCoinConfiguration> {
         if (Files.notExists(blockchainStore)) {
             Path dir = blockchainStore.getParent();
             Files.createDirectories(dir);
-            Files.createFile(blockchainStore);
             // flyway needs to create baseline
             flyway.setBaselineOnMigrate(true);
         }
@@ -49,8 +46,6 @@ public class FlywayBundle implements ConfiguredBundle<JiveCoinConfiguration> {
     }
 
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-        this.metricRegistry = bootstrap.getMetricRegistry();
-    }
+    public void initialize(Bootstrap<?> bootstrap) {}
 
 }

--- a/src/test/java/com/jivecoin/app/bundle/FlywayBundleTest.java
+++ b/src/test/java/com/jivecoin/app/bundle/FlywayBundleTest.java
@@ -4,12 +4,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.jivecoin.app.JiveCoinConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -17,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -36,58 +33,37 @@ class FlywayBundleTest {
     @BeforeEach
     void setUp() {
         flywayBundle = new FlywayBundle(flyway);
-        flywayBundle.metricRegistry = metricRegistry;
         configuration = new JiveCoinConfiguration();
         configuration.database = dsFactory;
+        String dbUrl = "jdbc:sqlite:."; // make the hostname '.' to avoid creating unnecessary files
+
+        // define behavior
+        when(environment.metrics()).thenReturn(metricRegistry);
+        when(dsFactory.build(metricRegistry, "flyway")).thenReturn(dataSource);
+        when(dsFactory.getUrl()).thenReturn(dbUrl);
     }
 
-    @Nested
-    @DisplayName("initialize")
-    class Initialize {
-        @Test
-        @DisplayName("initialize sets the MetricRegistry")
-        void testInitialize() {
-            Bootstrap<?> bootstrap = mock(Bootstrap.class);
-            when(bootstrap.getMetricRegistry()).thenReturn(metricRegistry);
-            flywayBundle.initialize(bootstrap);
-            assertEquals(metricRegistry, flywayBundle.metricRegistry);
-        }
+    @Test
+    @DisplayName("invalid hostname throws exception")
+    void testRun_HostnameNotDefined() {
+        when(dsFactory.getUrl()).thenReturn("jdbc:sqlite");
+        assertThrows(
+            RuntimeException.class,
+            () -> flywayBundle.run(configuration, environment),
+            "Configuration for the database URL is missing hostname"
+        );
     }
 
-    @Nested
-    @DisplayName("run")
-    class Run {
-        @BeforeEach
-        void setUp() {
-            String dbUrl = "jdbc:sqlite:."; // make the hostname '.' to avoid creating unnecessary files
+    @Test
+    @DisplayName("should run flyway migrate")
+    void testRun() throws IOException {
+        // method under test
+        flywayBundle.run(configuration, environment);
 
-            // define behavior
-            when(dsFactory.build(metricRegistry, "flyway")).thenReturn(dataSource);
-            when(dsFactory.getUrl()).thenReturn(dbUrl);
-        }
-
-        @Test
-        @DisplayName("invalid hostname throws exception")
-        void testRun_HostnameNotDefined() {
-            when(dsFactory.getUrl()).thenReturn("jdbc:sqlite");
-            assertThrows(
-                RuntimeException.class,
-                () -> flywayBundle.run(configuration, environment),
-                "Configuration for the database URL is missing hostname"
-            );
-        }
-
-        @Test
-        @DisplayName("should run flyway migrate")
-        void testRun() throws IOException {
-            // method under test
-            flywayBundle.run(configuration, environment);
-
-            // assertions
-            verify(flyway, times(1)).setDataSource(dataSource);
-            verify(flyway, times(1)).migrate();
-            verifyNoMoreInteractions(flyway);
-        }
+        // assertions
+        verify(flyway, times(1)).setDataSource(dataSource);
+        verify(flyway, times(1)).migrate();
+        verifyNoMoreInteractions(flyway);
     }
 
 }


### PR DESCRIPTION
Add the Gradle plugin for Flyway so that the migrations can be executed independent of the service. The reason is that if anyone deletes the `generated` folder, then the project won't compile so the service won't be able to start. Then there will be 2 ways to restore `generated`: either revert it back or execute the migrations and then `generateJooq`.